### PR TITLE
Updated deprecated `include` 

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,7 +1,7 @@
 ---
-- include: common.yml
-- include: fail2ban.yml
-- include: ntp.yml
-- include: sysstat.yml
-- include: ssh.yml
-- include: ufw.yml
+- import_tasks: common.yml
+- import_tasks: fail2ban.yml
+- import_tasks: ntp.yml
+- import_tasks: sysstat.yml
+- import_tasks: ssh.yml
+- import_tasks: ufw.yml

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,30 +1,30 @@
 ---
-- include: common.yml
+- import_tasks: common.yml
   tags:
     - server-setup
     - common
 
-- include: fail2ban.yml
+- import_tasks: fail2ban.yml
   tags:
     - server-setup
     - fail2ban
 
-- include: ntp.yml
+- import_tasks: ntp.yml
   tags:
     - server-setup
     - ntp
 
-- include: sysstat.yml
+- import_tasks: sysstat.yml
   tags:
     - server-setup
     - sysstat
 
-- include: ssh.yml
+- import_tasks: ssh.yml
   tags:
     - server-setup
     - ssh
 
-- include: ufw.yml
+- import_tasks: ufw.yml
   tags:
     - server-setup
     - ufw


### PR DESCRIPTION
Replace deprecated `include` statement to `import_tasks` ( required for [#106 of the website repo](https://github.com/pyslackers/website/issues/106) )