### PR TITLE
Set default locale

### DIFF
--- a/tasks/common.yml
+++ b/tasks/common.yml
@@ -37,6 +37,13 @@
     state: present
   with_items: "{{ locales }}"
 
+- name: Set default locale
+  lineinfile:
+    path: /etc/default/locale
+    state: present
+    regexp: '^LANG='
+    line: 'LANG="{{ locales[0] }}"'
+
 - name: "Set timezone {{ timezone }}"
   timezone:
     name: "{{ timezone }}"


### PR DESCRIPTION
The sirbot droplet had a `LANG="C"` locale and it was causing some bug for unicode as this locale can only handle ASCII. 

This set the locale to the first item in the locales list (by default `en_US.UTF8`)